### PR TITLE
Format timestamp display in backup status readme

### DIFF
--- a/src/simple_s3_backup/_base/_display.py
+++ b/src/simple_s3_backup/_base/_display.py
@@ -29,7 +29,11 @@ def update_display(use_cache: bool = True) -> None:
     outer_ls_locations = list(outer_directory_to_remote_size.keys())
     outer_ls_locations.sort(key=lambda path: (not path.endswith("/"), path))
 
-    now = datetime.datetime.now().astimezone(zoneinfo.ZoneInfo(key="America/New_York")).strftime("%B %-d, %Y at %I:%M %p ET")
+    now = (
+        datetime.datetime.now()
+        .astimezone(zoneinfo.ZoneInfo(key="America/New_York"))
+        .strftime("%B %-d, %Y at %I:%M %p ET")
+    )
     readme_lines = [
         "# DANDI Backup Status",
         "",

--- a/src/simple_s3_backup/_base/_display.py
+++ b/src/simple_s3_backup/_base/_display.py
@@ -29,7 +29,7 @@ def update_display(use_cache: bool = True) -> None:
     outer_ls_locations = list(outer_directory_to_remote_size.keys())
     outer_ls_locations.sort(key=lambda path: (not path.endswith("/"), path))
 
-    now = datetime.datetime.now().astimezone(zoneinfo.ZoneInfo(key="America/New_York")).isoformat()
+    now = datetime.datetime.now().astimezone(zoneinfo.ZoneInfo(key="America/New_York")).strftime("%B %-d, %Y at %I:%M %p ET")
     readme_lines = [
         "# DANDI Backup Status",
         "",


### PR DESCRIPTION
## Summary
Updated the timestamp formatting in the backup status display to use a human-readable format instead of ISO format.

## Changes
- Modified the `update_display()` function in `src/simple_s3_backup/_base/_display.py` to format the current timestamp using `strftime()` instead of `isoformat()`
- The new format displays the date and time as: "Month Day, Year at Hour:Minute AM/PM ET" (e.g., "January 15, 2024 at 02:30 PM ET")
- This improves readability of the backup status readme for end users

## Implementation Details
- The timestamp is still timezone-aware, using America/New_York timezone
- The `strftime()` format string `"%B %-d, %Y at %I:%M %p ET"` provides a more user-friendly representation compared to the ISO 8601 format

https://claude.ai/code/session_01CaDVy6a4tTiEUFxPGqEze1