### PR TITLE
Update file paths to use new backup directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ See also https://github.com/dandi/s3invsync for a more complicated approach that
 # Crontab
 
 ```bash
-0 22 * * * flock -n /orcd/data/dandi/001/flocks/backup_blobs_batch.lock sbatch /orcd/data/dandi/001/simple-s3-backup/scripts/backup_blobs_batch_deployment.sh
-#0 19 * * 0,3 flock -n /orcd/data/dandi/001/flocks/backup_zarr_batch.lock sbatch /orcd/data/dandi/001/simple-s3-backup/scripts/backup_zarr_batch_deployment.sh  # Zarr was disabled in May 2026
-0 18 * * * flock -n /orcd/data/dandi/001/flocks/backup_nonblobs.lock sbatch /orcd/data/dandi/001/simple-s3-backup/scripts/backup_nonblobs_deployment.sh
-0 6 * * * flock -n /orcd/data/dandi/001/flocks/update_dashboard.lock sbatch /orcd/data/dandi/001/simple-s3-backup/scripts/update_dashboard.sh
+0 22 * * * flock -n /orcd/data/dandi/001/backup/flocks/backup_blobs_batch.lock sbatch /orcd/data/dandi/001/backup/simple-s3-backup/scripts/backup_blobs_batch_deployment.sh
+#0 19 * * 0,3 flock -n /orcd/data/dandi/001/backup/flocks/backup_zarr_batch.lock sbatch /orcd/data/dandi/001/backup/simple-s3-backup/scripts/backup_zarr_batch_deployment.sh  # Zarr was disabled in May 2026
+0 18 * * * flock -n /orcd/data/dandi/001/backup/flocks/backup_nonblobs.lock sbatch /orcd/data/dandi/001/backup/simple-s3-backup/scripts/backup_nonblobs_deployment.sh
+0 6 * * * flock -n /orcd/data/dandi/001/backup/flocks/update_dashboard.lock sbatch /orcd/data/dandi/001/backup/simple-s3-backup/scripts/update_dashboard.sh
 ```

--- a/scripts/backup_blobs_batch_deployment.sh
+++ b/scripts/backup_blobs_batch_deployment.sh
@@ -9,6 +9,6 @@
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
 
-conda activate /orcd/data/dandi/001/s3-backup-environment
+conda activate /orcd/data/dandi/001/backup/s3-backup-environment
 
-flock -n /orcd/data/dandi/001/flocks/backup_blobs_batch_$SLURM_ARRAY_TASK_ID.lock s3backup dandi blobs $SLURM_ARRAY_TASK_ID
+flock -n /orcd/data/dandi/001/backup/flocks/backup_blobs_batch_$SLURM_ARRAY_TASK_ID.lock s3backup dandi blobs $SLURM_ARRAY_TASK_ID

--- a/scripts/backup_nonblobs_deployment.sh
+++ b/scripts/backup_nonblobs_deployment.sh
@@ -8,6 +8,6 @@
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
 
-conda activate /orcd/data/dandi/001/s3-backup-environment
+conda activate /orcd/data/dandi/001/backup/s3-backup-environment
 
-flock -n /orcd/data/dandi/001/flocks/backup_nonblobs_batch.lock s3backup dandi nonblobs $SLURM_ARRAY_TASK_ID
+flock -n /orcd/data/dandi/001/backup/flocks/backup_nonblobs_batch.lock s3backup dandi nonblobs $SLURM_ARRAY_TASK_ID

--- a/scripts/backup_zarr_batch_deployment.sh
+++ b/scripts/backup_zarr_batch_deployment.sh
@@ -9,6 +9,6 @@
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
 
-conda activate /orcd/data/dandi/001/s3-backup-environment
+conda activate /orcd/data/dandi/001/backup/s3-backup-environment
 
-flock -n /orcd/data/dandi/001/flocks/backup_zarr_batch_$SLURM_ARRAY_TASK_ID.lock s3backup dandi zarr $SLURM_ARRAY_TASK_ID
+flock -n /orcd/data/dandi/001/backup/flocks/backup_zarr_batch_$SLURM_ARRAY_TASK_ID.lock s3backup dandi zarr $SLURM_ARRAY_TASK_ID

--- a/scripts/update_dashboard.sh
+++ b/scripts/update_dashboard.sh
@@ -7,11 +7,11 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-conda activate /orcd/data/dandi/001/s3-backup-environment
+conda activate /orcd/data/dandi/001/backup/s3-backup-environment
 
-cd /orcd/data/dandi/001/backup-status
+cd /orcd/data/dandi/001/backup/backup-status
 git pull
-flock -n /orcd/data/dandi/001/flocks/update_dashboard.lock sbatch s3backup dandi dashboard
+flock -n /orcd/data/dandi/001/backup/flocks/update_dashboard.lock sbatch s3backup dandi dashboard
 git add .
 git commit --message "update"
 git push

--- a/scripts/update_manifest.sh
+++ b/scripts/update_manifest.sh
@@ -6,9 +6,9 @@
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
 
-conda activate /orcd/data/dandi/001/s3-backup-environment
+conda activate /orcd/data/dandi/001/backup/s3-backup-environment
 
 s3backup dandi manifest
 
 # crontab -e
-# 0 */6 * * * flock -n /orcd/data/dandi/001/flocks/update_manifest.lock sbatch /orcd/data/dandi/001/simple-s3-backup/scripts/update_manifest.sh
+# 0 */6 * * * flock -n /orcd/data/dandi/001/backup/flocks/update_manifest.lock sbatch /orcd/data/dandi/001/backup/simple-s3-backup/scripts/update_manifest.sh

--- a/src/simple_s3_backup/_base/_dandi.py
+++ b/src/simple_s3_backup/_base/_dandi.py
@@ -5,7 +5,7 @@ from ._utils import _deploy_subprocess
 
 
 def backup_dandi_nonblobs() -> None:
-    backup_directory = pathlib.Path("/orcd/data/dandi/001/s3dandiarchive")
+    backup_directory = pathlib.Path("/orcd/data/dandi/001/backup/s3dandiarchive")
 
     ls_command = "s5cmd ls s3://dandiarchive"
     ls_output = _deploy_subprocess(command=ls_command, ignore_errors=True)

--- a/src/simple_s3_backup/_base/_display.py
+++ b/src/simple_s3_backup/_base/_display.py
@@ -62,7 +62,7 @@ def update_display(use_cache: bool = True) -> None:
             ],
         },
     }
-    disk_space_json_file_path = pathlib.Path("/orcd/data/dandi/001/backup-status/data/disk.json")
+    disk_space_json_file_path = pathlib.Path("/orcd/data/dandi/001/backup/backup-status/data/disk.json")
     with disk_space_json_file_path.open(mode="w") as file_stream:
         json.dump(obj=disk_space_json, fp=file_stream)
 
@@ -88,14 +88,14 @@ def update_display(use_cache: bool = True) -> None:
             ],
         },
     }
-    content_json_file_path = pathlib.Path("/orcd/data/dandi/001/backup-status/data/content.json")
+    content_json_file_path = pathlib.Path("/orcd/data/dandi/001/backup/backup-status/data/content.json")
     with content_json_file_path.open(mode="w") as file_stream:
         json.dump(obj=content_json, fp=file_stream)
 
     readme_lines += json_to_markdown_table(json_table=content_json)
 
     readme = "\n".join(readme_lines)
-    readme_file_path = pathlib.Path("/orcd/data/dandi/001/backup-status/README.md")
+    readme_file_path = pathlib.Path("/orcd/data/dandi/001/backup/backup-status/README.md")
     with readme_file_path.open(mode="w") as file_stream:
         file_stream.write(readme)
 
@@ -144,7 +144,7 @@ def json_to_markdown_table(json_table: dict) -> list[str]:
 
 
 def _load_data(use_cache: bool = True) -> dict:
-    backup_directory = pathlib.Path("/orcd/data/dandi/001/s3dandiarchive")
+    backup_directory = pathlib.Path("/orcd/data/dandi/001/backup/s3dandiarchive")
     cache_directory = backup_directory.parent / "display_cache"
     cache_directory.mkdir(exist_ok=True)
 
@@ -213,7 +213,7 @@ def _load_data(use_cache: bool = True) -> dict:
         # Still unsure why...
         # TODO: investigate
         # For now just override with du
-        local_du_command = "du -sB1 /orcd/data/dandi/001/s3dandiarchive/blobs/"
+        local_du_command = "du -sB1 /orcd/data/dandi/001/backup/s3dandiarchive/blobs/"
         local_du_output = _deploy_subprocess(command=local_du_command)
         local_blob_size_in_bytes = int(local_du_output.split("\t")[0])
 

--- a/src/simple_s3_backup/_base/_update_manifest.py
+++ b/src/simple_s3_backup/_base/_update_manifest.py
@@ -24,7 +24,7 @@ def update_manifest(limit: int | None = None) -> None:
         Case 3b: If local size is greater than remote, then something is wrong so add it to the problem list
     Case 4: Local mtime is after remote mtime, size matches, so ensure the checksums match
     """
-    manifests_directory = pathlib.Path("/orcd/data/dandi/001/manifests")
+    manifests_directory = pathlib.Path("/orcd/data/dandi/001/backup/manifests")
     manifests_directory.mkdir(exist_ok=True)
 
     s5cmd_ls_blobs_file_path = manifests_directory / "s5cmd_ls_blobs.txt"
@@ -83,7 +83,7 @@ def update_manifest(limit: int | None = None) -> None:
 
     try:
         blob_ids_to_update = []
-        blobs_directory = pathlib.Path("/orcd/data/dandi/001/s3dandiarchive/blobs")
+        blobs_directory = pathlib.Path("/orcd/data/dandi/001/backup/s3dandiarchive/blobs")
         limit = limit or len(remote_blob_id_to_info)
         start_time = time.time()
         max_time = 60 * 60 * 3  # Max 3 hours


### PR DESCRIPTION
## Summary
This PR updates all hardcoded file paths throughout the codebase to reflect a reorganization of the backup directory structure. The changes move backup-related files and directories under a new `/backup/` subdirectory within `/orcd/data/dandi/001/`.

## Key Changes
- Updated backup data directory paths from `/orcd/data/dandi/001/s3dandiarchive` to `/orcd/data/dandi/001/backup/s3dandiarchive`
- Updated backup status directory paths from `/orcd/data/dandi/001/backup-status` to `/orcd/data/dandi/001/backup/backup-status`
- Updated manifests directory path from `/orcd/data/dandi/001/manifests` to `/orcd/data/dandi/001/backup/manifests`
- Updated conda environment path from `/orcd/data/dandi/001/s3-backup-environment` to `/orcd/data/dandi/001/backup/s3-backup-environment`
- Updated lock files directory from `/orcd/data/dandi/001/flocks` to `/orcd/data/dandi/001/backup/flocks`
- Updated script paths from `/orcd/data/dandi/001/simple-s3-backup` to `/orcd/data/dandi/001/backup/simple-s3-backup`

## Files Modified
- `src/simple_s3_backup/_base/_display.py` - Updated paths for disk.json, content.json, README.md, and backup directory
- `src/simple_s3_backup/_base/_update_manifest.py` - Updated manifests and blobs directory paths
- `src/simple_s3_backup/_base/_dandi.py` - Updated backup directory path
- `README.md` - Updated crontab examples with new paths
- `scripts/update_dashboard.sh` - Updated environment, working directory, and lock file paths
- `scripts/backup_blobs_batch_deployment.sh` - Updated environment and lock file paths
- `scripts/backup_nonblobs_deployment.sh` - Updated environment and lock file paths
- `scripts/backup_zarr_batch_deployment.sh` - Updated environment and lock file paths
- `scripts/update_manifest.sh` - Updated environment and lock file paths

## Implementation Details
All path updates are consistent across the codebase, centralizing backup-related resources under a single `/backup/` directory for improved organization and maintainability.

https://claude.ai/code/session_01KvBd4ThBP63xgvxhZdZWcf