### PR TITLE
Update conda environment path in deployment scripts

### DIFF
--- a/scripts/backup_blobs_batch_deployment.sh
+++ b/scripts/backup_blobs_batch_deployment.sh
@@ -8,7 +8,6 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-
-conda activate /orcd/data/dandi/001/backup/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/s3-backup-environment
 
 flock -n /orcd/data/dandi/001/backup/flocks/backup_blobs_batch_$SLURM_ARRAY_TASK_ID.lock s3backup dandi blobs $SLURM_ARRAY_TASK_ID

--- a/scripts/backup_nonblobs_deployment.sh
+++ b/scripts/backup_nonblobs_deployment.sh
@@ -7,7 +7,6 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-
-conda activate /orcd/data/dandi/001/backup/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/s3-backup-environment
 
 flock -n /orcd/data/dandi/001/backup/flocks/backup_nonblobs_batch.lock s3backup dandi nonblobs $SLURM_ARRAY_TASK_ID

--- a/scripts/backup_zarr_batch_deployment.sh
+++ b/scripts/backup_zarr_batch_deployment.sh
@@ -8,7 +8,6 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-
-conda activate /orcd/data/dandi/001/backup/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/s3-backup-environment
 
 flock -n /orcd/data/dandi/001/backup/flocks/backup_zarr_batch_$SLURM_ARRAY_TASK_ID.lock s3backup dandi zarr $SLURM_ARRAY_TASK_ID

--- a/scripts/update_dashboard.sh
+++ b/scripts/update_dashboard.sh
@@ -7,7 +7,7 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-conda activate /orcd/data/dandi/001/backup/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/s3-backup-environment
 
 cd /orcd/data/dandi/001/backup/backup-status
 git pull

--- a/scripts/update_manifest.sh
+++ b/scripts/update_manifest.sh
@@ -5,8 +5,7 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-
-conda activate /orcd/data/dandi/001/backup/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/s3-backup-environment
 
 s3backup dandi manifest
 


### PR DESCRIPTION
## Summary
Updated the conda environment activation path across all deployment scripts to use a new centralized environments directory structure.

## Changes
- Updated conda environment path from `/orcd/data/dandi/001/backup/s3-backup-environment` to `/orcd/data/dandi/001/environments/s3-backup-environment` in all deployment scripts
- Removed unnecessary blank lines before conda activation commands for consistency
- Affected scripts:
  - `scripts/backup_blobs_batch_deployment.sh`
  - `scripts/backup_nonblobs_deployment.sh`
  - `scripts/backup_zarr_batch_deployment.sh`
  - `scripts/update_manifest.sh`
  - `scripts/update_dashboard.sh`

## Details
This change reflects a reorganization of the conda environment storage location, moving from a backup-specific directory to a centralized environments directory. All scripts that activate the s3-backup-environment now reference the new path consistently.

https://claude.ai/code/session_01FPzpCmmxDfMUdcz9g8EVah