### PR TITLE
Update conda environment path in deployment scripts

### DIFF
--- a/scripts/backup_blobs_batch_deployment.sh
+++ b/scripts/backup_blobs_batch_deployment.sh
@@ -8,6 +8,6 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-conda activate /orcd/data/dandi/001/environments/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/name-s3+backup_env
 
 flock -n /orcd/data/dandi/001/backup/flocks/backup_blobs_batch_$SLURM_ARRAY_TASK_ID.lock s3backup dandi blobs $SLURM_ARRAY_TASK_ID

--- a/scripts/backup_nonblobs_deployment.sh
+++ b/scripts/backup_nonblobs_deployment.sh
@@ -7,6 +7,6 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-conda activate /orcd/data/dandi/001/environments/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/name-s3+backup_env
 
 flock -n /orcd/data/dandi/001/backup/flocks/backup_nonblobs_batch.lock s3backup dandi nonblobs $SLURM_ARRAY_TASK_ID

--- a/scripts/backup_zarr_batch_deployment.sh
+++ b/scripts/backup_zarr_batch_deployment.sh
@@ -8,6 +8,6 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-conda activate /orcd/data/dandi/001/environments/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/name-s3+backup_env
 
 flock -n /orcd/data/dandi/001/backup/flocks/backup_zarr_batch_$SLURM_ARRAY_TASK_ID.lock s3backup dandi zarr $SLURM_ARRAY_TASK_ID

--- a/scripts/update_dashboard.sh
+++ b/scripts/update_dashboard.sh
@@ -7,7 +7,7 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-conda activate /orcd/data/dandi/001/environments/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/name-s3+backup_env
 
 cd /orcd/data/dandi/001/backup/backup-status
 git pull

--- a/scripts/update_manifest.sh
+++ b/scripts/update_manifest.sh
@@ -5,7 +5,7 @@
 
 source /etc/profile.d/modules.sh  # When run via crontab, this is needed to load the modules
 module load miniforge
-conda activate /orcd/data/dandi/001/environments/s3-backup-environment
+conda activate /orcd/data/dandi/001/environments/name-s3+backup_env
 
 s3backup dandi manifest
 


### PR DESCRIPTION
## Summary
Updates the conda environment path across all deployment scripts to reference a renamed environment directory.

## Changes
- Updated conda environment activation path from `s3-backup-environment` to `name-s3+backup_env` in the following scripts:
  - `scripts/backup_blobs_batch_deployment.sh`
  - `scripts/backup_nonblobs_deployment.sh`
  - `scripts/backup_zarr_batch_deployment.sh`
  - `scripts/update_dashboard.sh`
  - `scripts/update_manifest.sh`

## Details
This change reflects a rename of the conda environment directory used by the backup and dashboard update processes. All five deployment scripts that activate this environment have been updated to point to the new environment path, ensuring consistency across the codebase.

https://claude.ai/code/session_019jGjcxQh5barzxrTJy3q7g