### PR TITLE
Add dashboard documentation and blob partition separation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,6 @@ See also https://github.com/dandi/s3invsync for a more complicated approach that
 
 
 
-# Dashboard
-
-The backup status dashboard is available at https://github.com/dandi/backup-status. It is updated daily via the `update_dashboard` cron job (see below).
-
-## Blob Partition Separation
-
-Blobs are distributed across two disk partitions (`001` and `002`) based on the first hexadecimal digit of each blob's head hash (task IDs 0–15, corresponding to hex digits `0`–`f`):
-
-| Partition | Head hash digits (hex) | Task IDs |
-|-----------|------------------------|----------|
-| `001`     | `0`–`9`                | 0–9      |
-| `002`     | `a`–`f`                | 10–15    |
-
-Zarr stores are stored entirely on partition `002` regardless of head hash.
-
-The `blobs <int>` subcommand accepts a task ID (0–15) and backs up all blobs whose three-character hex prefix starts with that digit (e.g., task ID `5` covers prefixes `500`–`5ff`). This allows 16 parallel backup jobs to run independently.
-
-The dashboard aggregates blob statistics from both partitions when reporting totals.
-
 # Crontab
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@ See also https://github.com/dandi/s3invsync for a more complicated approach that
 
 
 
+# Dashboard
+
+The backup status dashboard is available at https://github.com/dandi/backup-status. It is updated daily via the `update_dashboard` cron job (see below).
+
+## Blob Partition Separation
+
+Blobs are distributed across two disk partitions (`001` and `002`) based on the first hexadecimal digit of each blob's head hash (task IDs 0–15, corresponding to hex digits `0`–`f`):
+
+| Partition | Head hash digits (hex) | Task IDs |
+|-----------|------------------------|----------|
+| `001`     | `0`–`9`                | 0–9      |
+| `002`     | `a`–`f`                | 10–15    |
+
+Zarr stores are stored entirely on partition `002` regardless of head hash.
+
+The `blobs <int>` subcommand accepts a task ID (0–15) and backs up all blobs whose three-character hex prefix starts with that digit (e.g., task ID `5` covers prefixes `500`–`5ff`). This allows 16 parallel backup jobs to run independently.
+
+The dashboard aggregates blob statistics from both partitions when reporting totals.
+
 # Crontab
 
 ```bash

--- a/src/simple_s3_backup/_base/_display.py
+++ b/src/simple_s3_backup/_base/_display.py
@@ -8,6 +8,7 @@ import zoneinfo
 import yaml
 from tabulate2 import tabulate
 
+from ._globals import BLOBS_HEAD_TO_PARTITION
 from ._utils import _deploy_subprocess, _get_today
 
 
@@ -94,10 +95,33 @@ def update_display(use_cache: bool = True) -> None:
 
     readme_lines += json_to_markdown_table(json_table=content_json)
 
+    readme_lines += ["", "", ""]
+    readme_lines += json_to_markdown_table(json_table=_build_blob_partition_json())
+
     readme = "\n".join(readme_lines)
     readme_file_path = pathlib.Path("/orcd/data/dandi/001/backup/backup-status/README.md")
     with readme_file_path.open(mode="w") as file_stream:
         file_stream.write(readme)
+
+
+def _build_blob_partition_json() -> dict:
+    partition_to_hex_digits = collections.defaultdict(list)
+    for task_id, partition in BLOBS_HEAD_TO_PARTITION.items():
+        partition_to_hex_digits[partition].append(f"{task_id:x}")
+
+    partitions = sorted(partition_to_hex_digits)
+    return {
+        "subtitle": "Blob Partition Separation",
+        "headers": [
+            "Blobs are distributed across partitions based on the first hex digit of each blob's head hash."
+        ],
+        "data": {
+            "Partition": partitions,
+            "Head Hash Digits (hex)": [
+                ", ".join(f"`{d}`" for d in partition_to_hex_digits[p]) for p in partitions
+            ],
+        },
+    }
 
 
 def json_to_markdown_table(json_table: dict) -> list[str]:

--- a/src/simple_s3_backup/_base/_display.py
+++ b/src/simple_s3_backup/_base/_display.py
@@ -112,14 +112,10 @@ def _build_blob_partition_json() -> dict:
     partitions = sorted(partition_to_hex_digits)
     return {
         "subtitle": "Blob Partition Separation",
-        "headers": [
-            "Blobs are distributed across partitions based on the first hex digit of each blob's head hash."
-        ],
+        "headers": ["Blobs are distributed across partitions based on the first hex digit of each blob's head hash."],
         "data": {
             "Partition": partitions,
-            "Head Hash Digits (hex)": [
-                ", ".join(f"`{d}`" for d in partition_to_hex_digits[p]) for p in partitions
-            ],
+            "Head Hash Digits (hex)": [", ".join(f"`{d}`" for d in partition_to_hex_digits[p]) for p in partitions],
         },
     }
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation about the backup status dashboard and explains how blobs are distributed across disk partitions in the backup system.

## Key Changes
- Added a new "Dashboard" section documenting the backup status dashboard at https://github.com/dandi/backup-status and its daily update mechanism via the `update_dashboard` cron job
- Documented blob partition separation strategy:
  - Blobs are distributed across two partitions (`001` and `002`) based on the first hexadecimal digit of their head hash
  - Partition `001` stores blobs with head hash digits `0`–`9` (task IDs 0–9)
  - Partition `002` stores blobs with head hash digits `a`–`f` (task IDs 10–15) and all Zarr stores
- Explained the `blobs <int>` subcommand functionality, which accepts task IDs (0–15) to enable 16 parallel independent backup jobs
- Clarified that the dashboard aggregates statistics from both partitions when reporting totals

## Implementation Details
The documentation provides a clear reference table showing the partition-to-task-ID mapping and explains how the task ID system enables horizontal scaling of backup operations.

https://claude.ai/code/session_019L6YTFmGqBGke7cQEyjZxb